### PR TITLE
Exclude pushing of compiled .pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.exe
 *.o
 *.so
+*.pyc
  
 # Packages #
 ############


### PR DESCRIPTION
Change to gitignore to stop git pushing compiled .pyc files.
